### PR TITLE
Enhance battle and world map documentation with runtime details

### DIFF
--- a/FF8/TechnicalReference/Battle/BattleRuntime.md
+++ b/FF8/TechnicalReference/Battle/BattleRuntime.md
@@ -1,0 +1,99 @@
+---
+layout: default
+parent: Battle
+title: Battle Runtime
+permalink: /technical-reference/battle/battle-runtime/
+---
+
+The following information documents the PC 2000 battle runtime state machine and the main per-frame flow. It complements the file format pages by showing how loaded encounter data becomes an active battle.
+
+1. TOC
+{:toc}
+
+## Module entry
+
+The battle module is entered through `FFModuleHandler_main_loop` (`0x4706B0`). Field and world-map modules write a pending battle scene id, then the module handler stores it in `COMBAT_SCENE_ID` before launching the battle module.
+
+| Address | Name | Role |
+|---------|------|------|
+| `0x4706B0` | `FFModuleHandler_main_loop` | Top-level module dispatcher |
+| `0x46FEE0` | `FFFieldModule_field_main_loop` | Field module loop |
+| `0x53F0F0` | `FFWorldModule_worldmap_main_loop` | World-map module loop |
+| `0x47CCB0` | `FFBattleDirector_battleLoop` | Battle state machine and per-frame tick |
+| `0x1CFF6E0` | `COMBAT_SCENE_ID` | Active battle scene id |
+
+The battle director reaches the active battle tick when:
+
+| State field | Required value | Meaning |
+|-------------|----------------|---------|
+| `mode_StateGlobal` | `3` | Battle module active |
+| `mode3_subsub_step` | `3` | Battle init has reached the active substage |
+| `mode_3_subsubsubstep` | `4` | Active per-frame battle tick |
+
+## Initialization phases
+
+Before the per-frame tick begins, `FFBattleDirector_battleLoop` runs the battle module through a set of initialization substates:
+
+| Step | Description |
+|------|-------------|
+| 1 | Load `COMBAT_SCENE_ID` and the 128-byte scene.out encounter block (`scene_id << 7`) |
+| 2 | Clear all 11 battle slots, parse party members, junction stats, commands, auto-statuses and items |
+| 3 | Async-load battle stage geometry |
+| 4 | Initialize enemy slots from c0mxxx.dat data: level scaling, HP/stat formulas and innate statuses |
+| 5 | Resolve preemptive / back-attack outcome and ATB overrides |
+| 6 | Async-load enemy textures |
+| 7 | Run pre-battle checks such as Odin, Gilgamesh, dead timer and target visibility |
+| 8 | Enter active tick (`mode_3_subsubsubstep == 4`) |
+
+See [Encounters data (scene.out)](../battle-structure-sceneout/) for the encounter block layout loaded in step 1.
+
+## Active tick flow
+
+Within the active tick, the engine processes player input, ATB, pending actions, arbitration, damage/status resolution and presentation tasks in a fixed order.
+
+| Order | Function | Address | Role |
+|-------|----------|---------|------|
+| 1 | `BattleUI_InputPollAndMenuState` | `0x4A8772` | Poll input and drive command menu state |
+| 2 | `BattleATB_TickAndReady` | `0x4842B0` | Advance ATB and enqueue ready commands |
+| 3 | `BattlePendingAction_TransferToExecQueue` | `0x4847F0` | Move pending actions into the execution queue |
+| 4 | `BattleArbitration_SelectNextAction` | `0x485460` | Pick the next queued action; monster slots enter the AI VM |
+| 5 | `BattleAction_ResolveSpecialActionAndUpdateDamage` | `0x485160` | Resolve the action and bridge to damage/status handling |
+| 6 | `BattleTaskQueue_Tick` | `0x500CC0` | Dispatch presentation tasks |
+
+## Preemptive / back attack
+
+`Battle_InitPreemptiveBackAttackStatus` (`0x48AFD0`) runs during battle initialization after scene data has been loaded. Scripted battle flags can force or suppress specific outcomes.
+
+| Flag | Value | Effect |
+|------|-------|--------|
+| bit 7 | `0x80` | Suppress preemptive/back-attack; force normal start |
+| bit 5 | `0x20` | Force preemptive attack |
+| bit 6 | `0x40` | Force back attack |
+| bit 2 | `0x04` | Enable inherited battle countdown timer |
+| bit 1 | `0x02` | Suppress normal battle music handling |
+| bit 0 | `0x01` | Set cannot-run state |
+
+Random encounters normally use `ENCOUTER_BATTLE_FLAG == 0`. When no flag forces the result, the engine rolls `GetRandomInt()` and applies modifiers from enemy death immunity, party abilities and Initiative.
+
+| Result value | Outcome | Effect |
+|--------------|---------|--------|
+| `0` | Normal | Normal starting positions |
+| `1` | Preemptive | Party starts forward |
+| `2` | Back Attack | Party receives back-attack status |
+| `3` | Pincer | Known value, details not confirmed here |
+| `4` | Side Attack | Enemy side receives back-attack status |
+
+The result is stored in `BACK_PREEMTIVE_INFO` (`0x1D28E08`).
+
+## Battle end
+
+Battle end detection is part of the battle initialization/state machine family, not a separate module. `BATTLE_RESULT_CODE` (`0x1CFF6E7`) stores the final result code used by the end transition and post-battle handling.
+
+| Value | Meaning |
+|-------|---------|
+| `0` | Battle still active / no final result |
+| `1` | Victory |
+| `2` | Defeat or game-over path |
+| `3` | Escape |
+
+Note: Phoenix can intercept party wipe before game-over is committed. See [GF Summon Runtime](../gf-summon-runtime/) for the Phoenix auto-trigger path.

--- a/FF8/TechnicalReference/Battle/BattleSlotData.md
+++ b/FF8/TechnicalReference/Battle/BattleSlotData.md
@@ -1,0 +1,130 @@
+---
+layout: default
+parent: Battle
+title: Battle Slot Data
+permalink: /technical-reference/battle/battle-slot-data/
+---
+
+`BATTLE_SLOT_DATA` is the central per-slot runtime structure used by ATB, status, damage, targeting, command menus and enemy AI.
+
+1. TOC
+{:toc}
+
+## Slot array
+
+| Field | Value |
+|-------|-------|
+| Base address | `0x1D27B10` |
+| Stride | `0xD0` bytes |
+| Count | 11 slots (`0..10`) |
+
+| Slot range | Use |
+|------------|-----|
+| `0..2` | Party members |
+| `3..7` | Enemies (up to 5 active) |
+| `8..10` | GF-related runtime slots |
+
+Slot addresses are computed as:
+
+```
+slot_address = 0x1D27B10 + slot_id * 0xD0
+```
+
+Example: slot 3 is `0x1D27B10 + 3 * 0xD0 = 0x1D27D80`.
+
+## High-signal offsets
+
+| Offset | Size | Field | Notes / primary writer |
+|--------|------|-------|------------------------|
+| `+0x00` | 4 | `monster_info_section` | Enemy-only pointer (`0x48BBD0`) |
+| `+0x04` | 4 | `monster_ai_section` | Enemy-only pointer used by the AI VM |
+| `+0x08` | 4 | `status_2` | Authoritative status_2 (`0x493840`) |
+| `+0x0C` | 4 | `status_2_copy` | UI / mirror copy (`0x47E2D0`) |
+| `+0x10` | 4 | `max_atb` | Initialized by `0x484490` |
+| `+0x14` | 4 | `cur_atb` | Updated by `0x4842B0` |
+| `+0x18` | 4 | `current_hp` | Written by `Battle_ApplyDamageOrHeal` (`0x494410`) |
+| `+0x1C` | 4 | `max_hp` | Initialized by party/enemy setup |
+| `+0x44` | 16 | `elem_def[8]` | `int16[8]`; party from junctions, enemy from `.dat` info |
+| `+0x54` | 32 | `timer[16]` | Status timers |
+| `+0x7C` | 2 | `flag_data` | Active/ready state bitfield |
+| `+0x7E` | 2 | `immunity_flag_data` | Gravity immunity and related flags |
+| `+0x80` | 2 | `status_1` | Authoritative status_1 (`0x493840`) |
+| `+0x82` | 2 | `status_1_copy` | UI / mirror copy (`0x47E2D0`) |
+| `+0x84` | 2 | `target_info_mask` | Also used in GF shield HP tracking |
+| `+0x86` | 2 | `hit_status_1` | Party init (`0x48B310`) |
+| `+0x90` | 0x28 | `mental_res` | Byte-addressed mental resistances |
+| `+0xBB` | 1 | `com_file_id` | `0xFF` = empty slot |
+| `+0xBC` | 1 | `level` | Runtime battle level |
+| `+0xC1` | 1 | `spd` | Authoritative speed used by ATB |
+| `+0xCA` | 1 | `crisis_level` | Limit Break crisis level (`0x4941F0`) |
+
+## Status fields
+
+`status_1` is a 16-bit field at `+0x80`.
+
+| Bit | Mask | Status | Evidence |
+|-----|------|--------|----------|
+| 0 | `0x0001` | Death / KO | Set by `Battle_ApplyDamageOrHeal` when HP reaches 0 |
+| 2 | `0x0004` | Petrify | Tested with Death as `status_1 & 5` |
+| 6 | `0x0040` | Zombie | Set by enemy info initialization when the monster has the zombie flag |
+
+`status_2` is a 32-bit field at `+0x08`.
+
+| Bit | Mask | Status | Evidence |
+|-----|------|--------|----------|
+| 0 | `0x00000001` | Sleep | ATB and arbitration gating |
+| 1 | `0x00000002` | Haste | ATB increment base becomes 15 |
+| 2 | `0x00000004` | Slow | ATB increment base becomes 5 |
+| 3 | `0x00000008` | Stop | Blocks readiness and is handled during damage/status application |
+| 5 | `0x00000020` | Protect | Auto-status init from party abilities |
+| 6 | `0x00000040` | Shell | Auto-status init from party abilities |
+| 7 | `0x00000080` | Reflect | Auto-status init from party abilities |
+| 14 | `0x00004000` | Confuse-like | Target eligibility mask |
+| 16 | `0x00010000` | Eject | Checked and cleared by status commit code |
+| 30 | `0x40000000` | Has Magic | Set during party init |
+| 31 | `0x80000000` | GF Summoning | Signed status check in GF summon cleanup |
+
+## Composite masks
+
+| Mask | Usage |
+|------|-------|
+| `status_1 & 0x05` | Death or Petrify |
+| `status_2 & 0x0009` | Sleep or Stop |
+| `status_2 & 0x4009` | Sleep, Stop or confuse-like target rejection |
+| `status_2 & 0x180800` | Invulnerability flags; exact bit identities need more work |
+| `status_2 & 0x2004009` | Extended target ineligibility |
+| `status_1 & 0x25` | Death, Petrify or Berserk |
+
+## ATB update
+
+`BattleATB_TickAndReady` (`0x4842B0`) is called every active battle frame from `BattleUI_InputPollAndMenuState` (`0x4A8772`).
+
+Per slot, the ATB increment is:
+
+```
+base = 10
+base = 15 if status_2 & 0x2  (Haste)
+base = 5  if status_2 & 0x4  (Slow)
+
+cur_atb += base * K_MISC.atb_speed_multiplier * (spd + 30) / 100
+```
+
+A slot is processed only when it is active, alive, not petrified, not asleep/stopped and not already in a ready state. When `cur_atb >= max_atb`, `cur_atb` is clamped and the slot transitions either to an auto-command path or normal command menu readiness.
+
+| Condition | Result |
+|-----------|--------|
+| `status_1 & 0x20` or `status_2 & 0x2004000` | Auto-command path via `Battle_ProcessAutoCommand` |
+| Otherwise | Normal menu path via `BattleUI_EnqueueCommand(slot, 17, 128, 0)` |
+
+For party slots, the ATB values are mirrored to `BATTLE_ATB_UI_MIRROR` (`0x1CFF180`) for gauge display.
+
+## flag_data notes
+
+`flag_data` is heavily used by active/ready state logic. Confirmed initialization values:
+
+| Context | Value |
+|---------|-------|
+| Party init (`0x48B5F0`) | `*(_DWORD *)&slot.flag_data = 0x8801` |
+| Enemy init (`0x48BBD0`) | `*(_DWORD *)&slot.flag_data = 0x0011` |
+
+Note: treat `flag_data` as an opaque bitfield unless the exact writer/reader has been confirmed.

--- a/FF8/TechnicalReference/Battle/BattleStructure.md
+++ b/FF8/TechnicalReference/Battle/BattleStructure.md
@@ -10,6 +10,8 @@ Scene.out contains all the data for each encounter in the game, this includes en
 
 See the corresponding thread: <http://forums.qhimm.com/index.php?topic=15816.0>
 
+Runtime loading and field/world-map handoff are documented in [Encounter Trigger Runtime](../encounter-trigger-runtime/) and [Battle Runtime](../battle-runtime/).
+
 ## File Structure
 
 Scene.out contains no header. It is a raw list of 1024 encounters. Each encounter block consists of 128 bytes and has the following structure:

--- a/FF8/TechnicalReference/Battle/CommandAndActionPipeline.md
+++ b/FF8/TechnicalReference/Battle/CommandAndActionPipeline.md
@@ -1,0 +1,186 @@
+---
+layout: default
+parent: Battle
+title: Command and Action Pipeline
+permalink: /technical-reference/battle/command-and-action-pipeline/
+---
+
+This page documents the runtime path from a player or AI command to action resolution, damage, status application and draw/stock handling.
+
+1. TOC
+{:toc}
+
+## Overview
+
+The battle action path is:
+
+```
+Input / AI -> PendingAction -> ExecQueue -> Arbitration -> Resolve -> Damage / Status -> Presentation
+```
+
+| Stage | Main function | Address |
+|-------|---------------|---------|
+| Input / command menu | `BattleUI_InputPollAndMenuState` | `0x4A8772` |
+| Pending write | `BattlePendingAction_Write` | `0x484D20` |
+| Pending to execution queue | `BattlePendingAction_TransferToExecQueue` | `0x4847F0` |
+| Arbitration | `BattleArbitration_SelectNextAction` | `0x485460` |
+| Action resolve | `BattleAction_ResolveSpecialActionAndUpdateDamage` | `0x485160` |
+| Damage / HP write | `BattleAction_ResolveAndApplyDamage` / `Battle_ApplyDamageOrHeal` | `0x48FE20` / `0x494410` |
+| Damage event output | `Battle_UpdateDamage` | `0x48EF80` |
+
+## Command menu builder
+
+The command availability builder runs through the following chain:
+
+| Function | Address | Role |
+|----------|---------|------|
+| `BattleCommandMenu_MainState` | `0x4BB9E0` | Per-character command menu state machine |
+| `BattleCommandMenu_InitCommandSetAndLimitState` | `0x4BB910` | Rebuild command metadata and Limit Break availability |
+| `BattleLimit_ComputeCrisisAndToggleAttackSlot` | `0x4941F0` | Compute crisis level and toggle the attack slot |
+| `BattleCommandMenu_OpenSelectedCommand` | `0x4BC770` | Open submenu or accept a direct action |
+
+On command confirmation, the staged command is flushed to `BattlePendingAction_Write`. The write happens on target confirmation, not when the player only highlights a command.
+
+| Command type | Runtime notes |
+|--------------|---------------|
+| Magic | Requires a command entry in the 4-command set and stocked magic availability |
+| GF | Uses `command_id=0x03`; `command_arg` is the kernel GF id (`0x40..0x4F`) |
+| Draw | Uses a dedicated menu/target state machine; target draw list is refreshed from the enemy slot |
+| Item | Opens through the generic battle submenu dispatch path |
+
+## Pending action entry
+
+Pending actions are stored at `BATTLE_PENDING_ACTION_BUFFER` (`0x1D28D44`). There are three entries, each 8 bytes.
+
+| Offset | Size | Field | Description |
+|--------|------|-------|-------------|
+| `+0x0` | 2 | `target_mask` | Target selection bitmask |
+| `+0x2` | 1 | `attacker_slot` | Attacker slot index |
+| `+0x3` | 1 | `command_id` | Command category |
+| `+0x4` | 1 | `command_arg` | Spell id, GF kernel id, item id, etc. |
+| `+0x5` | 1 | padding | Always 0 |
+| `+0x6` | 1 | padding | Always 0 |
+| `+0x7` | 1 | `active` | 1 = entry is live |
+
+Example command bytes:
+
+| Command | Raw bytes | Notes |
+|---------|-----------|-------|
+| Attack, slot 1 to enemy | `10 00 01 01 00 00 00 01` | `target_mask=0x10`, `cmd_id=0x01` |
+| GF Ifrit, slot 0 | `08 80 00 03 42 00 00 01` | `cmd_arg=0x42` |
+| GF Diablos, slot 0 | `08 80 00 03 45 00 00 01` | `cmd_arg=0x45` |
+| GF Cerberus, slot 0 | `08 80 00 03 49 00 00 01` | Support GF, Double/Triple |
+
+`BattlePendingAction_TransferToExecQueue` copies live entries into:
+
+| Address | Name | Description |
+|---------|------|-------------|
+| `0x1D288E8` | `BATTLE_EXEC_QUEUE_BYTES` | Attacker, command and auxiliary byte lanes |
+| `0x1D288EE` | `BATTLE_EXEC_QUEUE_TARGET_MASKS` | Target mask array |
+
+The pending `active` flag is cleared after transfer.
+
+## command_id and resolver values
+
+| command_id | Command | Evidence |
+|------------|---------|----------|
+| `0x01` | Attack | Runtime capture |
+| `0x02` | Magic | Runtime injection / cast |
+| `0x03` | GF | Runtime capture |
+| `0x04` | Draw | Inferred from menu path |
+| `0x05` | Item | Inferred from menu path |
+
+At damage resolve time, `COMMAND_TYPE_ID` selects which kernel/runtime table supplies metadata:
+
+| COMMAND_TYPE_ID | Category | Metadata source |
+|-----------------|----------|-----------------|
+| `1` | Physical / Attack | `BATTLE_SLOT_DATA[attacker]` |
+| `2` | Magic | `K_MAGIC[action_id]` |
+| `4` | Item | `K_ITEM[action_id]` |
+| `6` | Draw | `K_MAGIC[action_id]` |
+| `7`, `23..27`, `29..34`, `38` | Command ability | `K_BATTLE_COMMAND_ABILITY[action_id]` |
+| `8` | Enemy attack | `K_ENEMY_ATTACK[action_id]` |
+| `16` | Slot / Selphie | `K_MAGIC[action_id]` |
+| `236` | Enemy attack variant | `K_ENEMY_ATTACK[action_id]` |
+| `247` | Magic variant | `K_MAGIC[action_id]` |
+| `254` (`0xFE`) | GF | `K_GF_JUNCTIONABLE[action_id - 64]` |
+
+## GF command_arg values
+
+GF `command_arg` values are kernel GF IDs, not zero-based indices. The resolver computes `gf_index = command_arg - 64`.
+
+| command_arg | GF | gf_index | Evidence |
+|-------------|----|----------|----------|
+| `0x40` | Quezacotl | 0 | Kernel order |
+| `0x41` | Shiva | 1 | Kernel order |
+| `0x42` | Ifrit | 2 | Runtime capture |
+| `0x43` | Siren | 3 | Kernel order |
+| `0x44` | Brothers | 4 | Kernel order |
+| `0x45` | Diablos | 5 | Runtime action globals |
+| `0x46` | Carbuncle | 6 | Kernel order |
+| `0x47` | Leviathan | 7 | Kernel order |
+| `0x48` | Pandemona | 8 | Runtime action globals |
+| `0x49` | Cerberus | 9 | Runtime action globals |
+| `0x4A` | Alexander | 10 | Kernel order |
+| `0x4B` | Doomtrain | 11 | Kernel order |
+| `0x4C` | Bahamut | 12 | Kernel order |
+| `0x4D` | Cactuar | 13 | Kernel order |
+| `0x4E` | Tonberry | 14 | Kernel order |
+| `0x4F` | Eden | 15 | Kernel order |
+
+## Damage pipeline
+
+`BattleAction_ResolveAndApplyDamage` (`0x48FE20`) first resolves metadata into hit globals:
+
+| Global | Source |
+|--------|--------|
+| `HIT_ELEMENT` | Kernel table `.element` |
+| `HIT_ATTACK_ENABLER` | Kernel table `.statusAttackEnabler` |
+| `HIT_STATUS_1` | Kernel table `.statuses0` |
+| `HIT_STATUS_2` | Kernel table `.statuses1` |
+| `HIT_ATTACK_HITPERCENT` | Kernel table `.hitPercent` |
+| `ATTACK_FLAG` | Kernel table `.attackFlags` |
+
+`Damage_ComputeRawDeltaFromAttackType` (`0x4922B0`) then dispatches by `attackType`:
+
+| Attack type path | Function |
+|------------------|----------|
+| Magic / GF | `ComputeMagicAndGFDamage` (`0x491AD0`) |
+| Curative | `computeCurativeMagic` (`0x493280`) / `computeCurativeGFMagicItem` |
+| Physical | Physical formula path |
+
+Finally, `Battle_ApplyDamageOrHeal` (`0x494410`) writes HP, clamps it to `[0, max_hp]`, sets KO when HP reaches 0, and performs attacker/target bookkeeping. `Battle_UpdateDamage` writes a 24-byte event record to `BATTLE_DAMAGE_RESULT_BUFFER` (`0x1D28344 + 24 * ATTACK_HIT_COUNT_1`) for the presentation layer.
+
+## Status pipeline
+
+Status application is split into a gating layer and an execution layer.
+
+| Step | Function | Address | Role |
+|------|----------|---------|------|
+| Payload | `BattleAction_ResolveAndApplyDamage` | `0x48FE20` | Populate `HIT_STATUS_1`, `HIT_STATUS_2`, `HIT_ATTACK_ENABLER` |
+| Gate | `BattleStatus_CanApplyHitStatus` | `0x492AC0` | Pure predicate: can this status land? |
+| Resolve | `BattleStatus_ApplyHitStatus` | `0x4914E0` | Mutual exclusion, double-apply prevention, clear/set bits |
+| Commit | `BattleStatus_ApplyAndSyncSlot` | `0x493840` | Write `status_1/2`, sync mirror, handle side effects |
+| Post-action | `BattleAction_ResolveAndApplyStatusResult` | `0x493D80` | HP-threshold status bits and final sync |
+
+`BattleStatus_CanApplyHitStatus` blocks all status application when the target is petrified (`status_1 & 0x04`) or has invulnerability flags (`status_2 & 0x180800`). Whether beneficial statuses bypass this gate through a separate path is not confirmed.
+
+## Draw system
+
+`Draw_ComputeStealCount` (`0x48FD20`) computes draw quantity (0-9) from attacker level, target level, attacker magic stat, `K_MAGIC[magic_id].drawResist`, and randomness.
+
+`getText` (`0x48D554`) has two draw paths:
+
+| Parameter | Path |
+|-----------|------|
+| `9` | Draw -> Cast; validates draw quantity, then casts the spell |
+| `10` | Draw -> Stock; computes quantity and loops stock increments |
+
+`Battle_MutateMagicStock` (`0x486A10`) adds one unit at a time to the magic stock for a slot and caps each stocked spell at 100.
+
+## Open questions
+
+- Exact formula inside `ComputeMagicAndGFDamage`.
+- How `ATTACK_FLAG` and `HIT_TYPE_2` modify edge cases such as misses and drain.
+- Whether support status applications bypass `BattleStatus_CanApplyHitStatus`.
+- Whether `Battle_MutateMagicStock` is the only stock mutation path outside battle.

--- a/FF8/TechnicalReference/Battle/EncounterTriggerRuntime.md
+++ b/FF8/TechnicalReference/Battle/EncounterTriggerRuntime.md
@@ -1,0 +1,187 @@
+---
+layout: default
+parent: Battle
+title: Encounter Trigger Runtime
+permalink: /technical-reference/battle/encounter-trigger-runtime/
+---
+
+This page documents how field and world-map encounter systems select a scene id and hand it to the battle module.
+
+1. TOC
+{:toc}
+
+## Summary
+
+Both field and world-map random encounter systems ultimately select a battle scene id, request module `3` (battle), and let `FFModuleHandler_main_loop` launch the battle module. The battle module then reads `COMBAT_SCENE_ID` and loads the corresponding 128-byte entry from [scene.out](../battle-structure-sceneout/).
+
+| Source | Scene id storage | Module request | Main selector |
+|--------|------------------|----------------|---------------|
+| Field random battle | `MenuState_opcode_menu_id` (`0x1CE4762`) | `globalFieldNextModuleID = 3` | `Field_Encounter_RollAndSelectScene` (`0x47CA90`) |
+| Field scripted battle | `MenuState_opcode_menu_id` (`0x1CE4762`) | `globalFieldNextModuleID = 3` | `SCRIPT_BATTLE` (`0x523294`) |
+| World map random battle | `WM_PENDING_SCENE_LO/HI` (`0x2036B4E/0x2036B4F`) | `WM_PENDING_MODULE_ID = 3` | `WM_Encounter_RollAndSelectScene` (`0x541C80`) |
+
+## Field random encounters
+
+`Field_Encounter_RollAndSelectScene` (`0x47CA90`) is called each frame from the field state machine (`Field_MainStateMachineTick`, `0x4789A0`).
+
+### Guard conditions
+
+Before danger processing, field random encounters are blocked when:
+
+| Condition | Meaning |
+|-----------|---------|
+| `globalFieldNextModuleID == 1` or `7` | Already transitioning |
+| `Field_IsCutsceneActive()` returns non-zero | Event/cutscene active |
+| `VAR_MAP_ADDRESS->unused8[3] != 0` | Field disables encounters |
+| `FIELD_STATE_MODE` is `2`, `3` or `4` | Menu / transition states |
+| `FIELD_ENC_DISABLED == 1` | Temporary encounter disable flag |
+| `RARE_ITEM_ABILITY_IN_IT & 0x08` | Enc-None active |
+
+### Danger meter
+
+The field encounter meter is a fractional accumulator. It increments by the current field's encounter rate, or half that rate with Enc-Half.
+
+```c
+if (RARE_ITEM_ABILITY_IN_IT & 0x04)
+    FIELD_ENC_METER += (*FIELD_ENC_RATE_PTR) >> 1;
+else
+    FIELD_ENC_METER += *FIELD_ENC_RATE_PTR;
+```
+
+When the meter exceeds `0x100`, a "step" is processed and the meter keeps its fractional remainder.
+
+### Danger rating and threshold
+
+Each step adds a danger amount from field region data. The accumulated danger rating is compared against a shuffled 256-byte threshold table.
+
+| Address | Name | Description |
+|---------|------|-------------|
+| `0x1CDC740` | `FIELD_ENC_METER` | Fractional encounter meter |
+| `0x1CDC74A` | `FIELD_DANGER_RATING` | Accumulated danger |
+| `0x1CD2FB8` | `FIELD_STEP_COUNTER` | Step counter, wraps at 256 |
+| `0x1CDC748` | `FIELD_CYCLE_BONUS` | Increases by 13 every 256 steps |
+| `0xB80A18` | `DANGER_LIMIT_TABLE` | 256-entry shuffled threshold table |
+| `0x1CF3D48` | `FIELD_ENC_RATE_PTR` | Pointer to field encounter rate byte |
+
+The threshold is:
+
+```
+threshold = FIELD_CYCLE_BONUS + DANGER_LIMIT_TABLE[FIELD_STEP_COUNTER]
+```
+
+An encounter triggers when `threshold < FIELD_DANGER_RATING`.
+
+### Formation selection
+
+When an encounter triggers, the field system selects from a 4-entry formation table at `FIELD_FORMATION_TABLE_PTR` (`0x1CF3D78`). The roll is based on `DANGER_LIMIT_TABLE[(TOTAL_ENCOUNTER + 1) & 0xFF]`.
+
+| Roll range | Slot | Nominal probability |
+|------------|------|---------------------|
+| `< 0x80` | formation 0 | 50% |
+| `< 0xC0` | formation 1 | 25% |
+| `< 0xF0` | formation 2 | 18.75% |
+| otherwise | formation 3 | 6.25% |
+
+If the selected formation matches `FIELD_LAST_FORMATION_ID`, selection falls through to the next formation to avoid immediate repeats.
+
+## Field scripted battles
+
+Field scripts can force battles through the `BATTLE` opcode. `SCRIPT_BATTLE` (`0x523294`) pops the battle flag byte and scene id from the script stack:
+
+```c
+ENCOUTER_BATTLE_FLAG = script_pop();
+MenuState_opcode_menu_id = script_pop();
+globalFieldNextModuleID = 3;
+```
+
+See [069_BATTLE](../../field/field-opcodes/069-battle/) for the field opcode page.
+
+## World-map random encounters
+
+`WM_Encounter_RollAndSelectScene` (`0x541C80`) is called from `FFWorldDirector` (`0x53F4B0`) during the world-map frame tick.
+
+### Guard conditions
+
+| Condition | Meaning |
+|-----------|---------|
+| `RARE_ITEM_ABILITY_IN_IT & 0x08 == 0` | Enc-None must be inactive |
+| `world_currentVehicle < 0x0A || world_currentVehicle == 128` | On foot, chocobo or car |
+| `isStateOfMovement != 0` | Party must be moving |
+
+Vehicle ids `>= 10` suppress random encounters except value `128`.
+
+### Terrain and meter
+
+World-map encounters use region and terrain:
+
+```c
+uint8_t region = wm_GetRegionNumber(WORLD_MAP_COORD_X, WORLD_MAP_COORD_Y);
+uint8_t terrain = *(Worldmap_weirdregister0_LocationDRAW + 13);
+```
+
+Terrain types 27 and 28 suppress encounters. Otherwise, the region/terrain pair is matched against wmset encounter data.
+
+The world-map meter increments by 16 each moving frame, or 4 with Enc-Half:
+
+```c
+WM_ENC_METER += 16 >> (2 * enc_half);
+```
+
+When `WM_ENC_METER > 256`, the meter resets to 0 and the system checks the threshold table.
+
+| Address | Name | Description |
+|---------|------|-------------|
+| `0x2040A5C` | `WM_ENC_METER` | World-map encounter meter |
+| `0x2040A5E` | `LOCOMOTION_METHOD` | Movement accumulator |
+| `0x2040A60` | `WM_STEP_AND_BONUS` | Step counter and bonus byte |
+| `0x2040A5F` | `WM_CYCLE_BONUS` | World-map cycle bonus |
+| `0xC75D20` | `Encounter_RandomRollArray` | World-map copy of the danger threshold table |
+| `0x20409E0` | `world_currentVehicle` | Current vehicle id |
+| `0x20400A0` | `WM_LAST_FORMATION_ID` | Last world-map encounter id |
+
+### Formation selection and handoff
+
+World-map formations come from wmset encounter tables. There are 8 formations per terrain. If the selected formation matches `WM_LAST_FORMATION_ID`, the system can re-roll up to two times.
+
+When the function returns success:
+
+```c
+WM_PENDING_MODULE_ID = 3;
+WM_PENDING_SCENE_LO = scene_id;
+WM_PENDING_SCENE_HI = scene_id_hi;
+ENCOUTER_BATTLE_FLAG = 0;
+TOWN_BATTLE_SCENE = 1;
+```
+
+Random world-map encounters therefore enter battle with `ENCOUTER_BATTLE_FLAG == 0`.
+
+## Battle module handoff
+
+Both field and world-map paths converge in the module handler.
+
+| Path | Sequence |
+|------|----------|
+| Field | Field encounter/script writes `MenuState_opcode_menu_id` and `globalFieldNextModuleID = 3`; module handler stores `COMBAT_SCENE_ID` |
+| World map | World director writes `WM_PENDING_MODULE_ID = 3` and scene bytes; module handler stores `COMBAT_SCENE_ID` |
+
+The battle module then reads:
+
+```
+ReadSceneOutFileForSpecificEncounter(COMBAT_SCENE_ID, &CURRENT_ENCOUNTER_DATA_SCENE_OUT)
+```
+
+The loaded scene.out block contributes its own battle flags; scripted `ENCOUTER_BATTLE_FLAG` is merged during initialization.
+
+## Function address summary
+
+| Address | Name | Role |
+|---------|------|------|
+| `0x47CA90` | `Field_Encounter_RollAndSelectScene` | Field encounter tick: increment, check, select and trigger |
+| `0x541C80` | `WM_Encounter_RollAndSelectScene` | World-map encounter tick |
+| `0x54A7F0` | `World_Encounter_CheckAndTrigger` | World-map encounter orchestrator |
+| `0x523294` | `SCRIPT_BATTLE` | Field script forced battle opcode |
+| `0x48AFD0` | `Battle_InitPreemptiveBackAttackStatus` | Preemptive/back-attack resolution |
+| `0x48B260` | `Battle_CheckPartyAbilityForPreemptive` | Party ability modifier |
+| `0x52B3A0` | `Field_IsCutsceneActive` | Cutscene/event gate |
+| `0x53F4B0` | `FFWorldDirector` | World-map state machine |
+| `0x4706B0` | `FFModuleHandler_main_loop` | Module dispatcher and battle handoff |

--- a/FF8/TechnicalReference/Battle/Encounter_Codes.md
+++ b/FF8/TechnicalReference/Battle/Encounter_Codes.md
@@ -5,6 +5,8 @@ title: Encounter Codes
 permalink: /technical-reference/battle/encounter-codes/
 ---
 
+Encounter IDs are battle scene IDs. Field scripts, field random encounters and world-map random encounters all select one of these IDs, then hand it to the battle module as `COMBAT_SCENE_ID`. See [Encounter Trigger Runtime](../encounter-trigger-runtime/) for the field/world-map selection and module handoff.
+
 ## Used Encounters
 
 | Encounter ID | Description                                        | Location                                 |

--- a/FF8/TechnicalReference/Battle/EnemyAIVMRuntime.md
+++ b/FF8/TechnicalReference/Battle/EnemyAIVMRuntime.md
@@ -1,0 +1,148 @@
+---
+layout: default
+parent: Battle
+title: Enemy AI VM Runtime
+permalink: /technical-reference/battle/enemy-ai-vm-runtime/
+---
+
+This page documents the runtime interpreter used for enemy behavior scripts in c0mxxx.dat section 8. For per-opcode authoring details, see [Battle Scripts](../battle-scripts/).
+
+1. TOC
+{:toc}
+
+## Architecture
+
+Enemy AI is executed through three layers when a monster becomes active:
+
+```
+BattleArbitration_SelectNextAction (0x485460)
+  -> EnemyAI_PrepareTurnAction (0x485610)
+     -> EnemyAI_DispatchSection (0x4877F0)
+        -> EnemyAI_VM_ExecuteScript (0x487DF0)
+```
+
+Damage application also routes back into AI for counter/death behavior:
+
+```
+Battle_ApplyDamageOrHeal (0x494410)
+  -> EnemyAI_DispatchSection(section=2 COUNTER)
+  -> EnemyAI_DispatchSection(section=3 DEATH)
+```
+
+## Data source
+
+Enemy scripts are stored in `.dat` section 8.
+
+| Offset | Length | Description |
+|--------|--------|-------------|
+| 0 | 4 bytes | Number of sub-sections (normally 3) |
+| 4 | 4 bytes | Offset to AI sub-section, relative to section start |
+| 8 | 4 bytes | Offset to text offsets |
+| 12 | 4 bytes | Offset to text sub-section |
+
+The AI sub-section contains offsets to code sub-sections:
+
+| Offset | Length | Description |
+|--------|--------|-------------|
+| 0 | 4 bytes | Offset to Init code |
+| 4 | 4 bytes | Offset to Turn code |
+| 8 | 4 bytes | Offset to Counter code |
+| 12 | 4 bytes | Offset to Death code |
+| 16 | 4 bytes | Offset to Pre-hit code |
+
+The bytecode pointer for a sub-section is:
+
+```
+ai_subsection_base + offset[section_index]
+```
+
+## Section dispatch
+
+`EnemyAI_DispatchSection` (`0x4877F0`) routes execution by section index.
+
+| Section | Name | Trigger | Description |
+|---------|------|---------|-------------|
+| 0 | Init | Monster appears | Runs once when the enemy enters battle |
+| 1 | Turn | Enemy ATB ready | Runs each enemy turn and increments `number_turn` |
+| 2 | Counter | After being hit | Checks death/petrify/berserk/sleep/stop gates first |
+| 3 | Death | HP reaches 0 | Can summon replacements, drop items, trigger events |
+| 4 | Pre-hit | Before hit resolves | Last-moment effects before damage commits |
+| 5-6 | Special | Fixed actions | Queues predefined commands |
+| 7 | Odin / Gilgamesh | Auto-trigger | Special GF summon handler |
+| 8 | Angelo | Auto-trigger | Angelo auto-action handler |
+
+For party slots (`0..2`), section 2 handles Counter ability, Cover and Return Damage rather than running enemy AI bytecode.
+
+## VM interpreter
+
+`EnemyAI_VM_ExecuteScript` (`0x487DF0`) is the bytecode interpreter. It dispatches a 61-case switch table at `0x487EDC`.
+
+| Behavior | Detail |
+|----------|--------|
+| Fetch | Reads one opcode byte from the current bytecode pointer |
+| Valid range | Opcodes `0x01..0x3D` plus `0x00` stop |
+| Stop | Opcode `0x00` ends script execution |
+| Default / NOP | Opcodes `0x0A`, `0x10`, `0x14`, `0x21` fall through to default |
+| Branching | Opcode `0x23` reads a 16-bit jump; opcode `0x02` conditionally skips by byte count |
+
+Observed interpreter signature:
+
+```c
+unsigned __int8 __usercall EnemyAI_VM_ExecuteScript@<al>(
+    unsigned int p_ai_subsection_init_code@<ebp>,
+    int          p_monster_slot_id,
+    uint8_t*     p_ai_current_subcode,
+    int          p_text_subsection,
+    int          p_text_offset_section
+);
+```
+
+## Runtime variables
+
+| Variable | Purpose |
+|----------|---------|
+| `op_id` | Current opcode byte |
+| `opcode_param_1` | First inline parameter |
+| `op_param_2`, `op_param_3` | Additional inline parameters |
+| `command_type` | Prepared action command type |
+| `section_position` | Prepared ability / spell id |
+| `jump_value` | Branch offset for IF/JUMP |
+| `monster_difficulty` | Difficulty tier (`0` low, `1` medium, `2` high) |
+| `ai_scratch_var` | General-purpose scratch variable |
+
+## Opcode groups
+
+The complete authoring reference remains [Battle Scripts](../battle-scripts/). Runtime grouping observed in the interpreter:
+
+| Group | Opcodes |
+|-------|---------|
+| Control flow | `0x00` STOP, `0x02` IF_CONDITION, `0x23` JUMP |
+| Attack setup | Magic, item, monster ability, ability info, drawn magic, execute action |
+| Targeting | Direct target, status target, target mask, random ability target |
+| Text / display | Display text, display and wait, text after attack, scan text |
+| Variables | Local/global variable set/add operations |
+| Monster management | Enter/leave, targetable/untargetable, enable/disable |
+| Status / stat modification | Stat changes, status tests, elemental defense writes |
+| Rewards / special | Drop/steal/reward and story-special behavior |
+
+Note: wiki opcode names and byte labels should be reconciled against [Battle Scripts](../battle-scripts/) before editing individual opcode sections. Do not assume that a decompiler label maps directly to the existing IfritAI name.
+
+## Important function addresses
+
+| Address | Name | Role |
+|---------|------|------|
+| `0x487DF0` | `EnemyAI_VM_ExecuteScript` | Bytecode interpreter |
+| `0x4877F0` | `EnemyAI_DispatchSection` | Section router |
+| `0x485610` | `EnemyAI_PrepareTurnAction` | Turn preparation, context setup |
+| `0x48A680` | `EnemyAI_CompareValues` | Comparison operator implementation |
+| `0x482C90` | `EnemyAI_LookupAbilityByIndex` | `.dat` section 7 ability lookup |
+| `0x48A830` | `EnemyAI_TargetHasStatus` | Target status predicate |
+| `0x4838C0` | `EnemyAI_GetTargetMaskFromMask` | Raw mask to target bitmask |
+| `0x483EF0` | `EnemyAI_SyncAIVarsToSlot` | Sync AI vars to battle slot data |
+| `0x487590` | `EnemyAI_GetTargetMemberCount` | Count members in target mask |
+| `0x4860A0` | `EnemyAI_CountAlivePartyMembers` | Count alive party members |
+| `0x4860D0` | `EnemyAI_CountAliveMonsters` | Count alive monsters |
+
+## Special GF-related sections
+
+Section 7 is used for Odin / Gilgamesh auto-actions and section 8 for Angelo auto-actions. These paths queue direct actions instead of reading normal monster bytecode. See [GF Summon Runtime](../gf-summon-runtime/) for the dispatch path into `MagicList_Logic`.

--- a/FF8/TechnicalReference/Battle/FileFormat_DAT.md
+++ b/FF8/TechnicalReference/Battle/FileFormat_DAT.md
@@ -636,6 +636,8 @@ value_hex = value% * 255 / 100
 | 12     | 4 bytes | Offset to death code                     |
 | 16     | 4 bytes | Offset to "before dying or taking a hit" |
 
+The runtime interpreter and section dispatch are documented in [Enemy AI VM Runtime](../enemy-ai-vm-runtime/). The per-opcode authoring reference is [Battle Scripts](../battle-scripts/).
+
 ### Texts
 
 Text offsets is a list of text positions (2 bytes each) in the text sub-section.

--- a/FF8/TechnicalReference/Battle/FileFormat_magfiles.md
+++ b/FF8/TechnicalReference/Battle/FileFormat_magfiles.md
@@ -25,6 +25,8 @@ Files starting with 10 00 00 00 09 00 00 00 are obviously TIM texture. Files sta
 
 <http://forums.qhimm.com/index.php?topic=15056.0>
 
+For runtime dispatch of GF summon effects, `MagicList_Logic`, `effect_id`, Odin/Gilgamesh/Phoenix/Angelo auto-actions and GF callback addresses, see [GF Summon Runtime](../gf-summon-runtime/).
+
 ## Environment objects
 
 **I'm aware it's chaotic**, like no tables and etc. but it's **up-to-date** information First, recognize file:

--- a/FF8/TechnicalReference/Battle/GFSummonRuntime.md
+++ b/FF8/TechnicalReference/Battle/GFSummonRuntime.md
@@ -1,0 +1,204 @@
+---
+layout: default
+parent: Battle
+title: GF Summon Runtime
+permalink: /technical-reference/battle/gf-summon-runtime/
+---
+
+This page documents the runtime dispatch for Guardian Force summon effects, special GF-style auto-actions and the shared `MagicList_Logic` effect table.
+
+1. TOC
+{:toc}
+
+## MagicList_Logic
+
+`MagicList_Logic` at `0xC81774` is a 400-entry array of battle effect callbacks. Magic spells, GF summon cinematics, enemy attacks, item animations and boss cinematics all share this table.
+
+| Address | Name | Type | Role |
+|---------|------|------|------|
+| `0xC81774` | `MagicList_Logic` | `int(*)(int)[400]` | Effect logic callbacks |
+| `0xC81DB8` | `MagicList_TextureLoad` | `void(*)(void)[400]` | Matching texture-loading callbacks |
+| `0x50AF20` | `BattleGF_LoadCallbackByMagicID` | function | Loads texture callback and writes active logic callback |
+| `0x21DFEC4` | `GF_CALLBACK_PTR` | function pointer | Currently active GF/effect callback |
+
+The `magicID` parameter passed to `BattleGF_LoadCallbackByMagicID` is a 1-based `effect_id`, not a GF kernel id and not a command argument.
+
+```c
+int idx = magicID - 1;
+MagicList_TextureLoad[idx]();
+*callback_out = MagicList_Logic[idx];
+```
+
+## Junctionable GF dispatch
+
+The player command path identifies a GF with `command_id=0x03` and `command_arg=0x40..0x4F`. The command argument indexes the kernel GF table:
+
+```
+gf_index = command_arg - 0x40
+effect_id = K_GF_JUNCTIONABLE[gf_index].magicID
+```
+
+The effect id is written to the action context at offset `+6`. `BattleActionSequence_Tick_GF_Cinematic` (`0x50B2A0`) later reads it and calls `BattleGF_LoadCallbackByMagicID`.
+
+| Context offset | Size | Field | Description |
+|----------------|------|-------|-------------|
+| `+0` | 1 | `attacker_slot` | Attacker slot id |
+| `+1` | 1 | `command_type` | `0xFE` for GF summon, other values for magic/special |
+| `+2` | 1 | `anim_state` | Animation state byte |
+| `+4` | 2 | `cmd_arg` | Ability / GF kernel id |
+| `+6` | 2 | `effect_id` | 1-based `MagicList_Logic` id |
+| `+12` | 4 | `damage_ctx_ptr` | Damage context pointer |
+| `+16` | 1 | `flags` | Additional flags |
+
+## Junctionable GF catalog
+
+Runtime evidence quality varies by GF. Keep the Confidence and Runtime fields when using this table for modding work.
+
+| GF | cmd_arg | effect_id | Entry | Init | Tick | Counter | Completion | Family | Confidence | Runtime |
+|----|---------|-----------|-------|------|------|---------|------------|--------|------------|---------|
+| Quezacotl | `0x40` | 116 | `0x6C3550` | `0x6C3640` | `0x6C3760` / `0x6C6660` | `0x6C3932` / `0x6C51F2` / `0x6C671D` | `0x6C3931` / `0x6C51F0` / `0x6C675D` | FamilyA | 96 (static) | Pending |
+| Shiva | `0x41` | 185 | `0x5C0D50` | inline | `0x5C7F50` | `0x5C7F8B` | Unknown | FamilyA | 92 (static) | Pending |
+| Ifrit | `0x42` | 201 | `0xB25780` | `0xB257E0` | `0xB25DF0` | `0xB25DFA` | `0xB26004` | FamilyB | 100 | PASS |
+| Siren | `0x43` | 95 | `0x739DA0` | `0x8DC540` shared | `0x739F40` | Unknown | Unknown | SharedInit | 95 (static) | Pending |
+| Brothers | `0x44` | 205 | `0xAF4520` | inline | `0xAF4B90` | `0xAF4B9A` | `0xAF4DA1` | Atypical | 75 | Tier-3 partial |
+| Diablos | `0x45` | 325 | `0x654210` | Unknown | `0x654350` driver | `0x65459D` | `0x654595` | Unknown | 90 | PASS |
+| Carbuncle | `0x46` | 278 | `0x680C50` | `0x680C80` | `0x680DF0` | `0x6811C8` | `0x6811BE` | FamilyA | 95 (static) | Pending |
+| Leviathan | `0x47` | 6 | `0xB58080` | inline | `0xB586F0` | `0xB586FA` | `0xB58901` | Atypical | 75 | Tier-3 partial |
+| Pandemona | `0x48` | 291 | `0x6ED250` | `0x6ED260` | `0x6ED350` | `0x6ED755` | `0x6ED749` | FamilyA | 95 | PASS |
+| Cerberus | `0x49` | 203 | `0xB0C1A0` | inline | `0xB0C820` | `0xB0C82A` | `0xB0CA31` | FamilyB | High | PASS |
+| Alexander | `0x4A` | 204 | `0xAFFCA0` | inline | `0xB00310` | `0xB0031A` | `0xB00521` | Atypical | 72 | Tier-3 partial |
+| Doomtrain | `0x4B` | 191 | `0x63E730` | inline | `0x6472C0` | `0x6472D1` | Unknown | FamilyA | 80 | Tier-3 partial |
+| Bahamut | `0x4C` | 202 | `0xB189A0` | inline | `0xB19010` | `0xB1901A` | `0xB19221` | Atypical | 72 | Tier-3 partial |
+| Cactuar | `0x4D` | 199 | `0x5A8750` | inline | `0x5AA3A0` | `0x5AA3B1` | Unknown | Atypical | 75 | Tier-3 partial |
+| Tonberry | `0x4E` | 90 | `0x762360` | `0x8DC540` shared | `0x7624D0` | `0x7625F9` | `0x762611` | SharedInit | 95 | PASS |
+| Eden | `0x4F` | 206 | `0xAE2DD0` | inline | `0xAE3470` | `0xAE347A` | `0xAE3681` | Atypical | 70 | Tier-3 partial |
+
+Note: Diablos has a thunk wrapper at `0x6541E0` in `MagicList_Logic`; it forwards to the real entry at `0x654210`.
+
+## GF families
+
+| Family | Shape | Examples |
+|--------|-------|----------|
+| FamilyA | Entry -> Init -> SequenceTick -> secondary SequenceTaskDriver | Pandemona, Doomtrain, Shiva, Odin |
+| FamilyB | Entry -> SequenceTick; the tick is the driver | Cerberus, Brothers, Leviathan, Alexander, Bahamut, Eden |
+| SharedInit | Entry -> `BdLinkTask_CreateAndInitContext` -> SequenceTick | Siren, Tonberry |
+| Atypical | Partially resolved or not clearly classified | Several low-confidence chains |
+
+All families use the same completion return pattern:
+
+```c
+return ((unsigned int)~*(WORD*)(statePtr + 10) >> 14) & 2;
+```
+
+## Shared GF infrastructure
+
+`BdLinkTask_CreateAndInitContext` (`0x8DC540`) is a shared task constructor used by multiple GFs.
+
+```c
+int __cdecl BdLinkTask_CreateAndInitContext(
+    _DWORD *dst_ctx,
+    int tick_fn,
+    int ctx_size,
+    int parent_ctx
+);
+```
+
+The second argument is the per-frame tick function, which is how the tick can be recovered from entries that use the shared constructor.
+
+Shared cinematic globals are reused across all GFs; only one GF cinematic runs at a time.
+
+| Address | Name | Description |
+|---------|------|-------------|
+| `0x27973EC` | `g_GfCinematic_SequenceCtxPtr` | Active GF sequence context |
+| `0x27973B8` | `g_GfCinematic_RuntimeSlotPtr` | Active GF runtime slot |
+| `0x27973BC` | `g_GfCinematic_RenderCtxPtr` | Active GF render context |
+| `0x27973C0` | `g_GfCinematic_SequenceStatePtr` | Active GF state pointer |
+| `0x2797624` | `g_GfCinematic_OffsetStack` | Active GF stack frame |
+
+## Special / non-junctionable GFs
+
+| Effect | effect_id | Entry | Mechanism | Notes |
+|--------|-----------|-------|-----------|-------|
+| Odin | 187 | `0x6472E0` | Battle-start auto-trigger | Crashes on direct injection; use caveat |
+| Griever | 69 | `0x6FE040` / thunk `0x6FE050` | Boss-only cinematic | Corrected from a former mid-function address |
+| Gilgamesh Zantetsuken | 329 | `0x58DB10` | Special action `0xF5` | Variant selected randomly |
+| Gilgamesh Masamune | 330 | `0x58DCF0` | Special action `0xF5` | Variant selected randomly |
+| Gilgamesh Excalibur | 328 | `0x58D930` | Special action `0xF5` | Variant selected randomly |
+| Gilgamesh Excalipoor | 327 | `0x58D760` | Special action `0xF5` | Variant selected randomly |
+| Phoenix | 140 | `0x6A6430` | Party-wipe auto-trigger | 64/255 trigger check |
+| Angelo Rush | 91 | via MagicList | Auto/counter | Rinoa action |
+| Angelo Recover | 93 | via MagicList | Auto/counter heal | Rinoa action |
+| Angelo Reverse | 94 | via MagicList | Counter revive | Rinoa action |
+| Angelo Search | 92 | via MagicList | Auto item find | Rinoa action |
+| ChocoFire | 97 | `0x729A60` | Chocobo/Boko variant | Entry mapped through table |
+| ChocoFlare | 98 | `0x721860` | Chocobo/Boko variant | Entry mapped through table |
+| ChocoMeteor | 99 | `0x717D30` | Chocobo/Boko variant | Entry mapped through table |
+| ChocoBocle | 100 | `0x70D390` | Chocobo/Boko variant | SharedInit-like pattern |
+
+## Odin and Gilgamesh
+
+`SG_ODIN_ANGEL_GILGA_FLAG` (`0x1CFE97A`) controls Odin, Phoenix, Gilgamesh, Angelo suppression and Witch-related state.
+
+| Bit | Value | Meaning | Set by |
+|-----|-------|---------|--------|
+| 1 | `0x02` | Has Odin | `SETODIN` field opcode |
+| 2 | `0x04` | Phoenix enabled | Phoenix Pinion use in battle |
+| 3 | `0x08` | Has Gilgamesh | Monster AI opcode 54; clears Odin simultaneously |
+| 4 | `0x10` | Suppress Angelo | Field script opcode |
+| 5 | `0x20` | Witch | `SETWITCH` field opcode |
+
+Odin is checked only at battle init (`mode_3_subsubsubstep == 3`). `ZANTETSUKEN_sub_482DF0` (`0x482E00`) requires the Odin flag and skips if any enemy has death immunity. The RNG is `32/255`, about 12.5%.
+
+Gilgamesh can trigger during battle init (`8/255`, about 3.1%) or during the active tick through `AngeloOdin_SpecialActionTick` (`0x482F80`) at `12/255` per checked tick. `GILGAMESH_ONESHOT_FLAG` prevents more than one Gilgamesh action in the same battle.
+
+In the Seifer disc-3 battle, monster AI opcode 54 clears Odin and sets Gilgamesh:
+
+```c
+SG_ODIN_ANGEL_GILGA_FLAG &= 0xFD;
+SG_ODIN_ANGEL_GILGA_FLAG |= 0x08;
+```
+
+## Phoenix
+
+Phoenix auto-triggers on party wipe only. It does not have a spontaneous per-frame trigger like Gilgamesh.
+
+`BattleFrame_PartyWipeCheck` (`0x486450`) scans party slots each active battle frame. If all party members are dead or petrified, it calls `Phoenix_BattleFrame_TriggerCheck` (`0x483270`).
+
+| Condition | Required value |
+|-----------|----------------|
+| At least one enemy alive | true |
+| At least one party member exists and is not petrified | true |
+| `SG_ODIN_ANGEL_GILGA_FLAG & 0x04` | Phoenix enabled |
+| `COMBAT_SCENE_ID != 317` | Not excluded scene |
+| RNG | `64/255`, about 25.1% |
+
+The result is `RELATED_ODIN_SUMMONED = 1`, which maps to `effect_id=140`.
+
+## Angelo variants
+
+Angelo requires Rinoa in the party (`com_file_id == 4`) and bit `0x10` of `SG_ODIN_ANGEL_GILGA_FLAG` clear.
+
+| Path | Function | Behavior |
+|------|----------|----------|
+| Per-frame auto-trigger | `AngeloOdin_SpecialActionTick` (`0x482F80`) | Recover, Reverse, Rush-like or Search priority cascade |
+| Turn counter | `Angelo_TurnCounter_TriggerCheck` (`0x482E80`) | Rinoa turn: Recover or Rush |
+| Damage counter | `Angelo_DamageCounter_ReverseCheck` (`0x482F10`) | Enemy attacks Rinoa: Angelo Reverse |
+
+| Variant index | effect_id | Ability | Command type |
+|---------------|-----------|---------|--------------|
+| 11 | 91 | Angelo Rush | `0xF0` |
+| 12 | 93 | Angelo Recover | `0xF0` |
+| 13 | 94 | Angelo Reverse | `0xF0` |
+| 14 | 92 | Angelo Search | `0xF0` |
+
+## Runtime evidence summary
+
+| GF | Test id | Key confirmations |
+|----|---------|-------------------|
+| Ifrit | GF_IFRIT_001 | cmd_arg `0x42`, callback pointer, tick and counter |
+| Diablos | GF_DIABLOS_001 | cmd_arg `0x45`, gravity HP reduction, `COMMAND_TYPE_ID=0xFE` |
+| Cerberus | GF_CERBERUS_001 | cmd_arg `0x49`, Double+Triple, support GF with 0 damage |
+| Doomtrain | GF_DOOMTRAIN_001 | Multi-status and damage pipeline |
+| Siren | GF_SIREN_001/002 | Silence infliction |
+| Pandemona | GF_PANDEMONA_001 | cmd_arg `0x48`, pending transfer, enemy HP decrease |
+| Tonberry | GF_TONBERRY_002 | Tick, counter and completion confirmed |

--- a/FF8/TechnicalReference/Battle/ai_info.md
+++ b/FF8/TechnicalReference/Battle/ai_info.md
@@ -19,6 +19,7 @@ Note: **pre-counter** code will **ONLY** be executed after an attack that kills 
 Note: if the **death** section is empty, it will function like a **_die_** opcode.  
 Note: if the **death** section is *NOT* empty, it is mandatory for it to eventually execute a **_die_** opcode, otherwise the monster will continue fighting, even on 0 HP, making the battle unwinnable for the player and forcing them to run. If running is not an option, this results in a soft lock.  
 
+The PC runtime interpreter, section dispatch functions and important addresses are documented in [Enemy AI VM Runtime](../enemy-ai-vm-runtime/).
 
 1. TOC
 {:toc}

--- a/FF8/TechnicalReference/Battle/escape.md
+++ b/FF8/TechnicalReference/Battle/escape.md
@@ -9,6 +9,8 @@ permalink: /technical-reference/battle/escape/
 When trying to run (R2 + L2), around every second (to be confirmed the exact time), there is a random computation if the escape happen.  
 The chance to escape is $$\frac{X}{255}$$, with $$X$$ depending on the following factors:  
 
+Scripted battles can also set `ENCOUTER_BATTLE_FLAG` bit 0 (`0x01`) during the field [BATTLE](../../field/field-opcodes/069-battle/) opcode, which sets the cannot-run state during battle init. Scene.out encounter data also has a Disable Escape battle flag; see [Encounters data (scene.out)](../battle-structure-sceneout/).
+
 if StructFirst or BackAttacked, $$X = 16$$  
 if ChanceForFirstStrike or BackAttack, $$X = 255$$  
 if all monster are disabled (Death or Petrify or Berserk or Sleep or Confusion), $$X = 255$$  

--- a/FF8/TechnicalReference/Battle/surprise_attack.md
+++ b/FF8/TechnicalReference/Battle/surprise_attack.md
@@ -8,6 +8,8 @@ permalink: /technical-reference/battle/surprise-attack/
 
 When starting a fight, there is some computation done to decide if you are lucky (or unlucky) for a strike first or a back attack.
 
+PC runtime function: `Battle_InitPreemptiveBackAttackStatus` (`0x48AFD0`). Scripted battles can force or suppress the result with `ENCOUTER_BATTLE_FLAG`; see [Battle Runtime](../battle-runtime/) and [Encounter Trigger Runtime](../encounter-trigger-runtime/).
+
 A RNG value is computed
 
 $$

--- a/FF8/TechnicalReference/Field/Field Opcodes/106_069_BATTLE.md
+++ b/FF8/TechnicalReference/Field/Field Opcodes/106_069_BATTLE.md
@@ -27,6 +27,16 @@ none
 
 Begin a battle with the given encounter id.
 
+Runtime function: `SCRIPT_BATTLE` (`0x523294`). The opcode pops the battle flags first, then the encounter id:
+
+```c
+ENCOUTER_BATTLE_FLAG = script_pop();
+MenuState_opcode_menu_id = script_pop();
+globalFieldNextModuleID = 3;
+```
+
+The field module hands `MenuState_opcode_menu_id` to the main module handler, which writes it to `COMBAT_SCENE_ID` before launching the battle module. See [Encounter Trigger Runtime](../../battle/encounter-trigger-runtime/) for the complete handoff.
+
 #### Battle Flags
 
   
@@ -34,7 +44,7 @@ Begin a battle with the given encounter id.
 
 +1: No escape?
 
-+2: Disable victory fanfare (battle music keeps playing after win/loss)
++2: Suppress normal battle music handling (reported as disabling victory fanfare / music behavior)
 
 +4: Inherit countdown timer from field.
 
@@ -42,8 +52,10 @@ Begin a battle with the given encounter id.
 
 +16: Use current music as battle music.
 
-+32: Force preemptive attacked
++32: Force preemptive attack
 
 +64: Force back attack
 
-+128: unknown
++128: Suppress preemptive/back-attack, forcing a normal battle start.
+
+Runtime-confirmed bits on PC 2000: `+1` sets the cannot-run state, `+2` changes normal battle music handling, `+4` enables inherited countdown timer handling, `+32` forces preemptive attack, `+64` forces back attack, and `+128` suppresses preemptive/back-attack. `+8` and `+16` need further verification.

--- a/FF8/TechnicalReference/Field/Field Opcodes/108_06B_BATTLEON.md
+++ b/FF8/TechnicalReference/Field/Field Opcodes/108_06B_BATTLEON.md
@@ -21,3 +21,5 @@ none
 #### Description
 
 Enables random battles.
+
+Runtime note: this clears the temporary field encounter disable flag checked by the field encounter tick. Random encounters are still blocked by cutscenes, field state, map encounter settings and Enc-None. See [Encounter Trigger Runtime](../../battle/encounter-trigger-runtime/).

--- a/FF8/TechnicalReference/Field/Field Opcodes/109_06C_BATTLEOFF.md
+++ b/FF8/TechnicalReference/Field/Field Opcodes/109_06C_BATTLEOFF.md
@@ -21,3 +21,5 @@ none
 #### Description
 
 Disables random battles.
+
+Runtime note: this sets the temporary field encounter disable flag checked by the field encounter tick. It prevents field random encounters without changing scripted battles started by [BATTLE](../069-battle/). See [Encounter Trigger Runtime](../../battle/encounter-trigger-runtime/).

--- a/FF8/TechnicalReference/Field/Field Opcodes/295_126_SETWITCH.md
+++ b/FF8/TechnicalReference/Field/Field Opcodes/295_126_SETWITCH.md
@@ -24,3 +24,5 @@ none
 #### Description
 
 This is only called once in the whole game - the first time you enter the Ragnarok in space. It unlocks Rinoa's alternate limit break after she becomes a sorceress.
+
+Runtime note: sets bit `0x20` in `SG_ODIN_ANGEL_GILGA_FLAG` (`0x1CFE97A`). The same byte also stores Odin, Phoenix, Gilgamesh and Angelo-related battle flags. See [GF Summon Runtime](../../battle/gf-summon-runtime/).

--- a/FF8/TechnicalReference/Field/Field Opcodes/296_127_SETODIN.md
+++ b/FF8/TechnicalReference/Field/Field Opcodes/296_127_SETODIN.md
@@ -21,3 +21,5 @@ none
 #### Description
 
 Unlocks Odin (as if you beat him).
+
+Runtime note: sets bit `0x02` in `SG_ODIN_ANGEL_GILGA_FLAG` (`0x1CFE97A`). During battle init, `ZANTETSUKEN_sub_482DF0` (`0x482E00`) checks this bit and can queue Odin with a `32/255` RNG check if enemies do not block death. See [GF Summon Runtime](../../battle/gf-summon-runtime/).

--- a/FF8/TechnicalReference/Field/Field Opcodes/359_166_DISABLEANGELO.md
+++ b/FF8/TechnicalReference/Field/Field Opcodes/359_166_DISABLEANGELO.md
@@ -24,3 +24,5 @@ none
 #### Description
 
 It uses 1 at the Esthar concourse and the Ragnarok airlock. Uses 0 in the ragnarok cockpit.
+
+Runtime note: controls bit `0x10` in `SG_ODIN_ANGEL_GILGA_FLAG` (`0x1CFE97A`). Angelo auto-actions require Rinoa in the party and this bit clear. See [GF Summon Runtime](../../battle/gf-summon-runtime/).

--- a/FF8/TechnicalReference/WorldMap/WorldMap_wmsetxx.md
+++ b/FF8/TechnicalReference/WorldMap/WorldMap_wmsetxx.md
@@ -332,6 +332,8 @@ A 16-entry header pointing into 16 formation groups. Each group is itself an off
 
 Used to organise encounter formations by type/tier.
 
+At runtime, `WM_Encounter_RollAndSelectScene` (`0x541C80`) selects from the wmset encounter tables by region/terrain. There are 8 formations per terrain; if the selected formation matches `WM_LAST_FORMATION_ID` (`0x20400A0`), the game can re-roll up to two times before handing the scene id to the battle module. See [World Map Encounters](worldmap_encounters) and [Encounter Trigger Runtime](../../battle/encounter-trigger-runtime/).
+
 ---
 
 ## Section 18: Region location IDs

--- a/FF8/TechnicalReference/WorldMap/worldmap_encounters.md
+++ b/FF8/TechnicalReference/WorldMap/worldmap_encounters.md
@@ -12,6 +12,8 @@ For each _Ground ID_, 8 different encounter slots are available, and are ordered
 These 8 slots each contain an [EncounterID](../../battle/encounter-codes/), these IDs are used to load the correct encounter from [scene.out](../../battle/battle-structure-sceneout/).  
 The following is a list of all the possible encounters in FF8's World Map.
 
+World-map random encounters are selected by `WM_Encounter_RollAndSelectScene` (`0x541C80`), called from `FFWorldDirector` (`0x53F4B0`). Encounters are blocked by Enc-None, most vehicle states, lack of movement, and some terrain ids (27 and 28). While moving, `WM_ENC_METER` (`0x2040A5C`) increases by 16 each frame, or 4 with Enc-Half. When it exceeds 256, the world map uses `Encounter_RandomRollArray` (`0xC75D20`) with the current step/cycle bonus and terrain encounter rate to decide whether an encounter triggers. The selected scene id is handed to the battle module through `WM_PENDING_MODULE_ID = 3` and `WM_PENDING_SCENE_LO/HI`. See [Encounter Trigger Runtime](../../battle/encounter-trigger-runtime/) for the full runtime flow.
+
 1. TOC
 {:toc}
 


### PR DESCRIPTION
## Summary

This PR expands the FF8 technical reference with runtime-focused documentation for the PC 2000 battle system.

It adds new Battle runtime pages covering:
- battle module initialization and active tick flow
- battle slot runtime data and high-signal offsets
- command, pending action, execution queue, arbitration, damage, status, draw, and stock flow
- field/world-map encounter trigger runtime and scene handoff
- enemy AI VM dispatch and bytecode execution
- GF summon dispatch through `MagicList_Logic`

It also updates existing Battle, Field opcode, and World Map pages with cross-links and runtime references for battle entry, encounter selection, escape behavior, preemptive/back attacks, Odin/Angelo toggles, and related systems.
